### PR TITLE
Removed unneeded / impossible to hit connection closure

### DIFF
--- a/taiwandatalab/dataquery.py
+++ b/taiwandatalab/dataquery.py
@@ -20,7 +20,6 @@ def get_sqldata(my_query):
 	cur.execute(query) 
 
 	return cur.fetchall()
-	con.close()
 
 
 def get_colnames(table, metrics_dict):
@@ -46,7 +45,6 @@ def get_colnames(table, metrics_dict):
 			colnames.append(key)
 			
 	return colnames
-	con.close()
 
 
 def chartjs_input(metrics_dict, sql_rows, chart_title, yaxis, table):


### PR DESCRIPTION
Because of the return statements, you'll never hit the `con.close()`s. The good news is when you exit scope, the connections should get cleaned up by the garbage collector. If you did want to be explicit (or didn't know if connections were properly cleaned), you could use a `try: finally:` to execute code after returning. For instance

```
try:
    return colnames
finally:
    con.close()
```